### PR TITLE
Add check for do_not_age tag to avoid re-processing mobs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 release/
 logo.xcf
+.DS_Store

--- a/data/arrested_development/functions/check.mcfunction
+++ b/data/arrested_development/functions/check.mcfunction
@@ -2,11 +2,11 @@
 #
 # Called by: arrested_development:detect (advancement)
 
-execute as @e[name="baby", distance=..16, nbt=!{Age:0}, sort=nearest, limit=1] run function arrested_development:arrest_development
-execute as @e[name="Baby", distance=..16, nbt=!{Age:0}, sort=nearest, limit=1] run function arrested_development:arrest_development
+execute as @e[name="baby", distance=..16, nbt=!{Age:0}, tag=!do_not_age, sort=nearest, limit=1] run function arrested_development:arrest_development
+execute as @e[name="Baby", distance=..16, nbt=!{Age:0}, tag=!do_not_age, sort=nearest, limit=1] run function arrested_development:arrest_development
 
-execute as @e[name="grow", distance=..16, sort=nearest, limit=1] run function arrested_development:cancel
-execute as @e[name="Grow", distance=..16, sort=nearest, limit=1] run function arrested_development:cancel
+execute as @e[name="grow", distance=..16, tag=do_not_age, sort=nearest, limit=1] run function arrested_development:cancel
+execute as @e[name="Grow", distance=..16, tag=do_not_age, sort=nearest, limit=1] run function arrested_development:cancel
 execute as @e[name="grow up", distance=..16, tag=do_not_age, sort=nearest, limit=1] run function arrested_development:cancel
 execute as @e[name="Grow Up", distance=..16, tag=do_not_age, sort=nearest, limit=1] run function arrested_development:cancel
 execute as @e[name="Grow up", distance=..16, tag=do_not_age, sort=nearest, limit=1] run function arrested_development:cancel

--- a/overlay_48/data/arrested_development/function/check.mcfunction
+++ b/overlay_48/data/arrested_development/function/check.mcfunction
@@ -2,11 +2,11 @@
 #
 # Called by: arrested_development:detect (advancement)
 
-execute as @e[name="baby", distance=..16, nbt=!{Age:0}, sort=nearest, limit=1] run function arrested_development:arrest_development
-execute as @e[name="Baby", distance=..16, nbt=!{Age:0}, sort=nearest, limit=1] run function arrested_development:arrest_development
+execute as @e[name="baby", distance=..16, nbt=!{Age:0}, tag=!do_not_age, sort=nearest, limit=1] run function arrested_development:arrest_development
+execute as @e[name="Baby", distance=..16, nbt=!{Age:0}, tag=!do_not_age, sort=nearest, limit=1] run function arrested_development:arrest_development
 
-execute as @e[name="grow", distance=..16, sort=nearest, limit=1] run function arrested_development:cancel
-execute as @e[name="Grow", distance=..16, sort=nearest, limit=1] run function arrested_development:cancel
+execute as @e[name="grow", distance=..16, tag=do_not_age, sort=nearest, limit=1] run function arrested_development:cancel
+execute as @e[name="Grow", distance=..16, tag=do_not_age, sort=nearest, limit=1] run function arrested_development:cancel
 execute as @e[name="grow up", distance=..16, tag=do_not_age, sort=nearest, limit=1] run function arrested_development:cancel
 execute as @e[name="Grow Up", distance=..16, tag=do_not_age, sort=nearest, limit=1] run function arrested_development:cancel
 execute as @e[name="Grow up", distance=..16, tag=do_not_age, sort=nearest, limit=1] run function arrested_development:cancel


### PR DESCRIPTION
If you name a baby mob and another one is closer, it doesn't run the code on the one you just named making it so it doesn't turn into a permanent baby. If this happens, then the name tag wouldn't work and you would have to do it again.

It should now prevent a mob that has already been turned into a permanent baby from being treated like it hasn't been turned into a permanent baby.