### PR TITLE
Recently bred mobs can be turned into babies [BUG]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 release/
 logo.xcf
+.DS_Store
+.vscode/

--- a/data/arrested_development/functions/check.mcfunction
+++ b/data/arrested_development/functions/check.mcfunction
@@ -2,8 +2,11 @@
 #
 # Called by: arrested_development:detect (advancement)
 
-execute as @e[name="baby", distance=..16, nbt=!{Age:0}, sort=nearest, limit=1] run function arrested_development:arrest_development
-execute as @e[name="Baby", distance=..16, nbt=!{Age:0}, sort=nearest, limit=1] run function arrested_development:arrest_development
+# temporarily store age of nearby entities in a scoreboard
+execute as @e[distance=..16] store result score @s age run data get entity @s Age
+
+execute as @e[name="baby", distance=..16, scores={age=..-1}, sort=nearest, limit=1] run function arrested_development:arrest_development
+execute as @e[name="Baby", distance=..16, scores={age=..-1}, sort=nearest, limit=1] run function arrested_development:arrest_development
 
 execute as @e[name="grow", distance=..16, sort=nearest, limit=1] run function arrested_development:cancel
 execute as @e[name="Grow", distance=..16, sort=nearest, limit=1] run function arrested_development:cancel
@@ -17,5 +20,6 @@ execute as @e[name="growup", distance=..16, tag=do_not_age, sort=nearest, limit=
 execute as @e[name="GrowUp", distance=..16, tag=do_not_age, sort=nearest, limit=1] run function arrested_development:cancel
 execute as @e[name="Growup", distance=..16, tag=do_not_age, sort=nearest, limit=1] run function arrested_development:cancel
 
+scoreboard players reset @e[distance=..16] age
 
 advancement revoke @s only arrested_development:detect

--- a/data/arrested_development/functions/setup.mcfunction
+++ b/data/arrested_development/functions/setup.mcfunction
@@ -1,0 +1,6 @@
+# Desc: Setup scoreboards and other one-time actions
+#
+# Called by: #minecraft:load
+
+# Temporary storage for mob ages to detect if they can be made permababies
+scoreboard objectives add age dummy

--- a/data/arrested_development/functions/uninstall.mcfunction
+++ b/data/arrested_development/functions/uninstall.mcfunction
@@ -1,0 +1,7 @@
+# Desc: Cleanup any remaining data pack data
+#
+# Called by: nothing. This is a manual function to aid in cleanup
+
+# Temporary storage for mob ages to detect if they can be made permababies
+
+scoreboard objectives remove age

--- a/data/minecraft/tags/functions/load.json
+++ b/data/minecraft/tags/functions/load.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "arrested_development:setup",
         "arrested_development:second"
     ]
 }

--- a/overlay_48/data/arrested_development/function/check.mcfunction
+++ b/overlay_48/data/arrested_development/function/check.mcfunction
@@ -2,8 +2,11 @@
 #
 # Called by: arrested_development:detect (advancement)
 
-execute as @e[name="baby", distance=..16, nbt=!{Age:0}, sort=nearest, limit=1] run function arrested_development:arrest_development
-execute as @e[name="Baby", distance=..16, nbt=!{Age:0}, sort=nearest, limit=1] run function arrested_development:arrest_development
+# temporarily store age of nearby entities in a scoreboard
+execute as @e[distance=..16] store result score @s age run data get entity @s Age
+
+execute as @e[name="baby", distance=..16, scores={age=..-1}, sort=nearest, limit=1] run function arrested_development:arrest_development
+execute as @e[name="Baby", distance=..16, scores={age=..-1}, sort=nearest, limit=1] run function arrested_development:arrest_development
 
 execute as @e[name="grow", distance=..16, sort=nearest, limit=1] run function arrested_development:cancel
 execute as @e[name="Grow", distance=..16, sort=nearest, limit=1] run function arrested_development:cancel
@@ -17,5 +20,6 @@ execute as @e[name="growup", distance=..16, tag=do_not_age, sort=nearest, limit=
 execute as @e[name="GrowUp", distance=..16, tag=do_not_age, sort=nearest, limit=1] run function arrested_development:cancel
 execute as @e[name="Growup", distance=..16, tag=do_not_age, sort=nearest, limit=1] run function arrested_development:cancel
 
+scoreboard players reset @e[distance=..16] age
 
 advancement revoke @s only arrested_development:detect

--- a/overlay_48/data/arrested_development/function/setup.mcfunction
+++ b/overlay_48/data/arrested_development/function/setup.mcfunction
@@ -1,0 +1,6 @@
+# Desc: Setup scoreboards and other one-time actions
+#
+# Called by: #minecraft:load
+
+# Temporary storage for mob ages to detect if they can be made permababies
+scoreboard objectives add age dummy

--- a/overlay_48/data/arrested_development/function/uninstall.mcfunction
+++ b/overlay_48/data/arrested_development/function/uninstall.mcfunction
@@ -1,0 +1,7 @@
+# Desc: Cleanup any remaining data pack data
+#
+# Called by: nothing. This is a manual function to aid in cleanup
+
+# Temporary storage for mob ages to detect if they can be made permababies
+
+scoreboard objectives remove age

--- a/overlay_48/data/minecraft/tags/function/load.json
+++ b/overlay_48/data/minecraft/tags/function/load.json
@@ -1,5 +1,6 @@
 {
     "values": [
+        "arrested_development:setup",
         "arrested_development:second"
     ]
 }


### PR DESCRIPTION
After a mob has had a baby, it has a breeding cooldown. The game tracks that cooldown by setting their Age NBT to a positive number and then decrementing it each tick until it reaches 0.

The data pack assumes that adults have an age of 0, because commands can only check if an NBT tag _is_ a specific value, instead of checking if it is _less than_ that value.

I added a scoreboard to temporarily store the Age of nearby mobs. This allows the check function to filter by a range of Age. I also made it so the scoreboard is setup, kept clean, and can be easily uninstalled using the uninstall function.

